### PR TITLE
Removed React dependency from podspect

### DIFF
--- a/ios/ReactNativeSocketMobile.podspec
+++ b/ios/ReactNativeSocketMobile.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
   s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
   s.dependency "SKTCaptureObjC", "~> 1.0"
 
 end


### PR DESCRIPTION
This dependency creates many problems for people who created their react native app using `react-native init` and then added Cocoapods after that. Adding this without a React pod will cause cocoapods to install React 0.11.0. If we add React as a pod and point it to the node_modules version, then we get duplicate name conflicts since our primary app already contains React. I thought the post_install commands from your example in the readme would solve this, but it doesn't.